### PR TITLE
service role arn "undefined method"

### DIFF
--- a/custom/handlers/ruby/ec2_node.rb
+++ b/custom/handlers/ruby/ec2_node.rb
@@ -214,8 +214,8 @@ class Ec2Node < Sensu::Handler
       })
       if (dyn_resp.items[0].key?('fixed_access_key_id') && dyn_resp.items[0].key?('fixed_secret_access_key')) then
         assumed_role = {
-          access_key_id: dyn_resp.items[0].fixed_access_key_id,
-          secret_access_key: dyn_resp.items[0].fixed_secret_access_key
+          access_key_id: dyn_resp.items[0]['fixed_access_key_id'],
+          secret_access_key: dyn_resp.items[0]['fixed_secret_access_key']
         }
         path = '/stashes'
         api_request('POST', path) do |req|
@@ -233,7 +233,7 @@ class Ec2Node < Sensu::Handler
         end
         return Aws::Credentials.new(assumed_role[:access_key_id], assumed_role[:secret_access_key])
       else
-        role_arn = dyn_resp.items[0].key?('service_role_arn') ? dyn_resp.items[0].service_role_arn : "arn:aws:iam::#{account_id}:role/AsyServiceRole"
+        role_arn = dyn_resp.items[0].key?('service_role_arn') ? dyn_resp.items[0]['service_role_arn'] : "arn:aws:iam::#{account_id}:role/AsyServiceRole"
         sts = Aws::STS::Client.new({region: region_server})
         sts_resp = sts.assume_role({
           role_arn: role_arn,


### PR DESCRIPTION
As it seems, this is a problem with newer AWS SDK versions changing the way you access entries.
I was able to replicate your issue locally in irb and fix it:

``` ruby
irb(main):024:0> dyn_resp.items[0].service_role_arn
Traceback (most recent call last):
        2: from /usr/bin/irb:11:in `<main>'
        1: from (irb):24
NoMethodError (undefined method `service_role_arn' for #<Hash:0x000055da33284840>)
irb(main):025:0> dyn_resp.items[0]['service_role_arn']
=> "arn:aws:iam::874399895105:role/DEV-SENSU-SAAS-CUSTOMER-AsyServiceRole-MWSJL0TWBB6W"
```

Please verify whether this fixes your issue in ECS and merge this PR then @ameenfathullah .